### PR TITLE
Add libCEED to the suite

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -134,5 +134,10 @@ repos = {
         "repo_url": "https://github.com/CEED/Laghos.git",
         "branch": None,
         "commit_id": "a7f6123d42847f6bdbdb614f5af876541f49cd16"
-    }
+    },
+    "libCEED": {
+        "repo_url": "https://github.com/CEED/libCEED.git",
+        "branch": "main",
+        "commit_id": "83ae4962eb1665164b53413c90f83e857c5b69b9"
+    },
 }

--- a/src/hiptestsuite/applications/hpc_apps/libceed/libceed.py
+++ b/src/hiptestsuite/applications/hpc_apps/libceed/libceed.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023 Intel Finland Oy. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from hiptestsuite.TesterRepository import Tester, Test, TestData
+from hiptestsuite.Test import HIPTestData, TestResult, HIP_PLATFORM
+from typing import Union, List
+from hiptestsuite.test_classifier import TestClassifier
+from hiptestsuite.applications.hpc_apps.libceed.libceed_build_amd import BuildRunAmd
+from hiptestsuite.common.hip_get_packages import HipPackages
+from hiptestsuite.common.hip_shell import execshellcmd
+
+import os
+import re
+
+# Common class to clone, set up, build and run test
+class PrepareTest():
+    def __init__(self, cwd):
+        self.cwdAbs = cwd
+        self.app_path = os.path.join(self.cwdAbs,\
+        "src/hiptestsuite/applications/hpc_apps/libceed/libCEED")
+        self.thistestpath = self.app_path
+        self.prepareobj = None
+        self.libceed_repo = "" # Default
+        self.libceed_branch = ""
+        self.libceed_commitId = ""
+
+    def set_libceed_repoinfo(self, test_data: HIPTestData):
+        validrepconfig = True
+        if test_data.repos["libCEED"].repo_url != None:
+            self.libceed_repo = test_data.repos["libCEED"].repo_url
+        else:
+            print("invalid config: no repo")
+            validrepconfig = False
+        if test_data.repos["libCEED"].branch != None:
+            self.libceed_branch = test_data.repos["libCEED"].branch
+        if test_data.repos["libCEED"].commit_id != None:
+            self.libceed_commitId = test_data.repos["libCEED"].commit_id
+        return validrepconfig
+
+    def downloadtest(self, logFile, test_data: HIPTestData):
+        return HipPackages().pull_repo(logFile, self.libceed_repo,\
+        self.libceed_branch, self.libceed_commitId, "libCEED")
+
+    def buildtest(self, logFile, platform, cuda_target):
+        if platform == HIP_PLATFORM.amd:
+            self.prepareobj = BuildRunAmd(self.thistestpath, logFile)
+        else:
+            print("Invalid/Unsupported Platform")
+            return False
+        if not self.prepareobj:
+            return False
+        return self.prepareobj.buildtest()
+
+    def clean(self):
+        if self.prepareobj != None:
+            self.prepareobj.clean()
+
+    def runtest(self, testnum):
+        if self.prepareobj != None:
+            self.prepareobj.runtest(testnum)
+
+    def parse_result(self, testnum):
+        if self.prepareobj != None:
+            return self.prepareobj.parse_result(testnum)
+        return False
+
+class LIBCEED(TestClassifier):
+    def __init__(self):
+        TestClassifier.__init__(self)
+
+    def add_matched_with_names(self, matched_with_names: Union[None, dict] = None):
+        TestClassifier.add_matched_with_names(self, {"libceed": matched_with_names})
+
+class UNIT(TestClassifier):
+    def __init__(self):
+        LIBCEED.__init__(self)
+
+    def add_matched_with_names(self, matched_with_names: Union[None, dict] = None):
+        LIBCEED.add_matched_with_names(self, {"libceed": matched_with_names})
+
+class LIBCEED_UNIT_TEST(Tester, PrepareTest):
+    def __init__(self):
+        Tester.__init__(self)
+        self.cwd = os.getcwd()
+        PrepareTest.__init__(self, self.cwd)
+
+    def getTests(self) -> List[Test]:
+        test = Test()
+        test.test_name = self.__class__.__name__
+        classifier = UNIT()
+        classifier.add_matched_with_names()
+        test.classifiers = [classifier]
+        test.tester = self
+        return [test]
+
+    def clean(self):
+        PrepareTest.clean(self)
+
+    def test(self, test_data: HIPTestData):
+        print("=============== libCEED UNIT test ===============")
+        # Set repo info
+        isrepocfgvalid =  self.set_libceed_repoinfo(test_data)
+        if not isrepocfgvalid:
+            test_data.test_result = TestResult.ERROR
+            return
+
+        # Create the log directory
+        resultLogDir = test_data.log_location
+        with open(resultLogDir + "/libceed_unit.log", 'w+') as testLogger:
+            res = self.downloadtest(testLogger, test_data)
+            test_data.test_result = TestResult.FAIL
+            if not res:
+                return
+            res = self.buildtest(testLogger, test_data.HIP_PLATFORM, test_data.build_for_cuda_target)
+            if not res:
+                return
+            self.runtest(1)
+            # Parse the test result
+            if self.parse_result(1):
+                test_data.test_result = TestResult.PASS
+

--- a/src/hiptestsuite/applications/hpc_apps/libceed/libceed_build_amd.py
+++ b/src/hiptestsuite/applications/hpc_apps/libceed/libceed_build_amd.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023 Intel Finland Oy. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import re
+import tempfile
+from hiptestsuite.common.hip_shell import *
+from hiptestsuite.applications.hpc_apps.libceed.libceed_parser_common import LibceedParser
+
+class BuildRunAmd():
+    def __init__(self, thistestpath, logFile):
+        self.thistestpath = thistestpath
+        self.logFile = logFile
+        self.runlog = None
+        self.rocm_path = os.environ.get('ROCM_PATH')
+        if not self.rocm_path:
+            self.rocm_path = "/opt/rocm"
+
+    def configure_build_libceed(self):
+        path_check = os.path.join(self.thistestpath, "lib/libceed.so")
+        if os.path.exists(path_check):
+            print("libceed already built at ", path_check)
+            return True
+        make_variables = "FORTRAN=0 "
+
+        make_variables += " ROCM_DIR=" + self.rocm_path
+
+        print("libceed build in progress ..")
+        cmd = "cd " + self.thistestpath + " && "
+        cmd += ("make configure " + make_variables
+                + " OPT='-O2 -march=native' && make")
+        runlogdump = tempfile.TemporaryFile("w+")
+        print("building using command: ", cmd)
+        execshellcmd_largedump(cmd, self.logFile, runlogdump, None)
+        runlogdump.close()
+        if not os.path.exists(path_check):
+            print("libceed Build Failed, not found at: ", path_check)
+            return False
+        return True
+
+    def buildtest(self):
+        if not self.configure_build_libceed():
+            print("libceed configuration and build failed ..")
+            return False
+        return True
+
+    def runtest(self, testnum):
+        print("Running libCEED Test" + str(testnum))
+        cmd = "cd " + self.thistestpath + " && "
+        cmd += "make BACKENDS=/gpu/hip/shared search=t3 exclude=t319 test"
+        env = os.environ.copy()
+        env['LD_LIBRARY_PATH'] = (self.rocm_path + '/lib:'
+                                  + env['LD_LIBRARY_PATH'])
+        self.runlog = tempfile.TemporaryFile("w+")
+        execshellcmd_largedump(cmd, self.logFile, self.runlog, env)
+
+    def clean(self):
+        print("Cleaning libceed..")
+        if self.runlog != None:
+            self.runlog.close()
+
+    def parse_result(self, testnum):
+        return LibceedParser(self.runlog).parse(testnum)
+

--- a/src/hiptestsuite/applications/hpc_apps/libceed/libceed_parser_common.py
+++ b/src/hiptestsuite/applications/hpc_apps/libceed/libceed_parser_common.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023 Intel Finland Oy. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import re
+
+class LibceedParser():
+    def __init__(self, results):
+        results.seek(0)
+        logbytes = results.read()
+        self.results = logbytes
+
+    def parse(self, testnum):
+        passcount = self.results.count("PASS")
+        failcount = self.results.count("FAIL:")
+        return passcount >= 32 and failcount == 0

--- a/src/hiptestsuite/common/hip_get_packages.py
+++ b/src/hiptestsuite/common/hip_get_packages.py
@@ -63,6 +63,10 @@ class HipPackages():
         self.mfemapppath = os.path.join(self.mfemrootpath, "mfem/")
         self.laghosrootpath = os.path.join(self.cwdAbs, "src/hiptestsuite/applications/hpc_apps/laghos/")
         self.laghosapppath = os.path.join(self.laghosrootpath, "Laghos/")
+        # libCEED
+        self.libceedrootpath = os.path.join(self.cwdAbs, "src/hiptestsuite/applications/hpc_apps/libceed/")
+        self.libceedapppath = os.path.join(self.libceedrootpath, "libCEED/")
+
 
     def pull_repo(self, logFile, repo, branch, commitId, reponame):
         repo_root_path = ""
@@ -132,6 +136,13 @@ class HipPackages():
             repo_root_path = self.laghosapppath
             repo_location = self.laghosrootpath
             repo_dir = "Laghos"
+        elif reponame == "libCEED":
+            repo_root_path = self.libceedapppath
+            repo_location = self.libceedrootpath
+            repo_dir = "libCEED"
+        else:
+            print("repository: " + reponame + " does not exist in hip_get_packages.py")
+            return False
 
         if  os.path.isdir(repo_root_path) and os.path.isdir(repo_root_path + "/.git"):
             print(reponame + " already exist")
@@ -149,8 +160,6 @@ class HipPackages():
             ((commitId == "") or (commitId in currentcommitid)):
                 print("This repo is up to date with config")
                 return True
-        else:
-            print(reponame + " does not exist")
 
         # Update the repo
         print("Updating: " + reponame)


### PR DESCRIPTION
Added for AMD platform and tested locally on gfx906.

This patch continued the work started by @franz in #3. Changes made to the original patch:
* Made libCEED build on AMD platform.
* Switched to upstream libCEED repository
* Dropped CHIP-SPV platform support.
